### PR TITLE
Detect infinite loop/crash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/de/neuland/jade4j/parser/BlockCommentNode.java
+++ b/src/main/java/de/neuland/jade4j/parser/BlockCommentNode.java
@@ -9,6 +9,7 @@ public class BlockCommentNode extends CommentNode {
 
 	@Override
 	public void execute(IndentWriter writer, JadeModel model, JadeTemplate template) throws JadeCompilerException {
+		model.visit(this, template);
 		if (!isBuffered()) {
 			return;
 		}

--- a/src/main/java/de/neuland/jade4j/parser/node/BlockNode.java
+++ b/src/main/java/de/neuland/jade4j/parser/node/BlockNode.java
@@ -12,6 +12,7 @@ public class BlockNode extends Node {
 	private String mode;
 
 	public void execute(IndentWriter writer, JadeModel model, JadeTemplate template) throws JadeCompilerException {
+		model.visit(this, template);
 		for (Node node : getNodes()) {
 			node.execute(writer, model, template);
 		}

--- a/src/main/java/de/neuland/jade4j/parser/node/ConditionalNode.java
+++ b/src/main/java/de/neuland/jade4j/parser/node/ConditionalNode.java
@@ -16,6 +16,7 @@ public class ConditionalNode extends Node {
 
 	@Override
 	public void execute(IndentWriter writer, JadeModel model, JadeTemplate template) throws JadeCompilerException {
+		model.visit(this, template);
 		for (IfConditionNode conditionNode : this.conditions) {
 			try {
 				if (conditionNode.isDefault() || checkCondition(model, conditionNode.getValue()) ^ conditionNode.isInverse()) {

--- a/src/main/java/de/neuland/jade4j/parser/node/IfConditionNode.java
+++ b/src/main/java/de/neuland/jade4j/parser/node/IfConditionNode.java
@@ -17,6 +17,7 @@ public class IfConditionNode extends Node {
 
 	@Override
 	public void execute(IndentWriter writer, JadeModel model, JadeTemplate template) throws JadeCompilerException {
+		model.visit(this, template);
 		block.execute(writer, model, template);
 	}
 

--- a/src/main/java/de/neuland/jade4j/parser/node/MixinInjectNode.java
+++ b/src/main/java/de/neuland/jade4j/parser/node/MixinInjectNode.java
@@ -16,6 +16,7 @@ public class MixinInjectNode extends AttributedNode {
 
 	@Override
 	public void execute(IndentWriter writer, JadeModel model, JadeTemplate template) throws JadeCompilerException {
+		model.visit(this, template);
 		MixinNode mixin = model.getMixin(getName());
 		if (mixin == null) {
 			throw new JadeCompilerException(this, template.getTemplateLoader(), "mixin " + getName() + " is not defined");

--- a/src/main/java/de/neuland/jade4j/parser/node/TagNode.java
+++ b/src/main/java/de/neuland/jade4j/parser/node/TagNode.java
@@ -56,6 +56,7 @@ public class TagNode extends AttributedNode {
 
     @Override
     public void execute(IndentWriter writer, JadeModel model, JadeTemplate template) throws JadeCompilerException {
+        model.visit(this, template);
         writer.newline();
         writer.append("<");
         writer.append(name);


### PR DESCRIPTION
Currently when we have templates include each other and using `block` improperly, there is a chance jade4j got infinite loop results in StackOverflowError, this will crash the process. This PR counts how many time each node being visited and if the count for specific node reach the threshold (currently set to 100) we fail the compile instead of crash.